### PR TITLE
17.3 as latest supported version

### DIFF
--- a/CBLSupportedDevices.json
+++ b/CBLSupportedDevices.json
@@ -1,7 +1,7 @@
 {
-    "max_os": "17.2.0",
+    "max_os": "17.3.0",
     "version": "1.0",
     
-    "DEBUG_max_os": "17.2.9",
+    "DEBUG_max_os": "17.3.9",
     "DEBUG_version": "1.0"
 }


### PR DESCRIPTION
Tested CowabungaLite (macOS) with iOS 17.3 Developer Beta 1, all features work as expected (especially I tested all aspects of Status Bar modifications)